### PR TITLE
Remove deprecation warnings and support newer ruby versions

### DIFF
--- a/lib/dibs/hmac.rb
+++ b/lib/dibs/hmac.rb
@@ -1,4 +1,4 @@
-require 'digest/hmac'
+require 'openssl'
 
 module DIBS
   class HMAC
@@ -81,7 +81,7 @@ module DIBS
         end
       end
     
-      OpenSSL::HMAC.hexdigest(OpenSSL::Digest::Digest.new('sha256'),Array(key).pack('H*'), param_string)
+      OpenSSL::HMAC.hexdigest(OpenSSL::Digest.new('sha256'),Array(key).pack('H*'), param_string)
     end
   
     def self.valid?(params, key)

--- a/spec/dibs/hmac_spec.rb
+++ b/spec/dibs/hmac_spec.rb
@@ -45,14 +45,14 @@ describe DIBS::HMAC do
     it 'should be true' do
       
       mac = "9c4d30a74ade9f93dfeca46edbdac110c8ec9b250185aab25a4555b3575d3ddc"
-      subject.valid?({:amount => "100", :merchant => "2222", :MAC => mac}, hmac_key).should be_true
+      subject.valid?({:amount => "100", :merchant => "2222", :MAC => mac}, hmac_key).should be_truthy
       
     end
     
     it 'should be false' do
       
       mac = "9c4d30a74ade9f93dfeca46edbdac110c8ec9b250185aab25a4555b3575d3ddc"
-      subject.valid?({:amount => "100", :MAC => mac}, hmac_key).should be_false
+      subject.valid?({:amount => "100", :MAC => mac}, hmac_key).should be_falsey
       
     end
     


### PR DESCRIPTION
When updating my Rails project to Ruby 2.2, I started getting deprecation warnings saying (somewhat cryptically) "Digest::Digest is deprecated; use Digest". I traced the warning to dibs_hmac. Digging around, I found that OpenSSL::Digest::Digest has been deprecated (without being marked as such) for ages, and the recommendation is to use OpenSSL::Digest instead. I updated the code to use the recommended version, and all the tests passed right away, and now the deprecation warning is gone. It would be great if you could merge this in to your main repo. Right now I'm using my own fork.