### PR TITLE
Add transactionId to DIBS_PARAM_NAMES

### DIFF
--- a/lib/dibs/hmac.rb
+++ b/lib/dibs/hmac.rb
@@ -44,6 +44,7 @@ module DIBS
       amount
       currency
       transaction
+      transactionId
       actionCode
       acquirer
       cardNumberMasked


### PR DESCRIPTION
Add transactionId to DIBS_PARAM_NAMES in order to support http://tech.dibspayment.com/batch/d2integratedpwapipaymentfunctionscanceltransaction
